### PR TITLE
Soc/timer stop comment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jira"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aquamarine",
  "chrono",
@@ -1870,7 +1870,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secure_credentials"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "security-framework 3.0.0",
 ]
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "timesheet-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "timesheet-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "chrono",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "timesheet-tui"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "crossterm",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "worklog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 
 [workspace.dependencies]
 tokio = { version = "1.*" }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -195,4 +195,10 @@ pub(crate) struct Start {
     pub issue: String,
     #[arg(short, long, long_help = "Comment to add to work log")]
     pub comment: Option<String>,
+    #[arg(
+        short,
+        long,
+        long_help = "Starting point if different from current time"
+    )]
+    pub start: Option<String>,
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod configuration;
 pub(crate) mod status;
+pub(crate) mod stop_timer;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -5,7 +5,7 @@ use jira::models::core::IssueKey;
 use log::debug;
 use worklog::date;
 use worklog::error::WorklogError;
-use worklog::types::LocalWorklog;
+use worklog::types::{LocalWorklog, Timer};
 use worklog::ApplicationRuntime;
 
 use crate::{cli::Status, get_runtime, table_report_weekly::table_report_weekly};
@@ -63,7 +63,28 @@ pub async fn execute(status: Status) -> Result<(), WorklogError> {
     // Prints the report
     table_report_weekly(&worklogs);
 
-    // print_info_about_time_codes(worklog_service, jira_keys_to_report);
+    match get_runtime().timer_service.get_active_timer() {
+        Ok(Some(timer)) => {
+            let elapsed_seconds = Local::now()
+                .signed_duration_since(timer.started_at)
+                .num_seconds();
+            let hours = elapsed_seconds / 3600;
+            let minutes = (elapsed_seconds % 3600) / 60;
+            println!(
+                "Active timer for {}, started at {} and current elapsed time is {:02}h {:02}m",
+                timer.issue_key,
+                timer.started_at.format("%Y-%m-%d %H:%M"),
+                hours,
+                minutes
+            );
+        }
+        Ok(None) => {
+            println!("No active timer");
+        }
+        Err(error) => {
+            eprintln!("Error when trying to find active timer: {error}");
+        }
+    }
     Ok(())
 }
 

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -5,7 +5,7 @@ use jira::models::core::IssueKey;
 use log::debug;
 use worklog::date;
 use worklog::error::WorklogError;
-use worklog::types::{LocalWorklog, Timer};
+use worklog::types::LocalWorklog;
 use worklog::ApplicationRuntime;
 
 use crate::{cli::Status, get_runtime, table_report_weekly::table_report_weekly};
@@ -77,6 +77,11 @@ pub async fn execute(status: Status) -> Result<(), WorklogError> {
                 hours,
                 minutes
             );
+            if let Some(comment) = timer.comment {
+                println!("Timer comment: {comment}");
+            } else {
+                println!("No comment associated with this timer");
+            }
         }
         Ok(None) => {
             println!("No active timer");

--- a/cli/src/commands/stop_timer.rs
+++ b/cli/src/commands/stop_timer.rs
@@ -1,0 +1,82 @@
+use chrono::{DateTime, Local};
+use std::process::exit;
+use worklog::error::WorklogError;
+use worklog::{date, ApplicationRuntime};
+
+pub(crate) fn discard_active_timer(runtime: &ApplicationRuntime) -> Result<(), WorklogError> {
+    println!("Discarding active timer");
+    match runtime.timer_service.discard_active_timer() {
+        Ok(timer) => {
+            println!(
+                "Timer for {} started at {} discarded",
+                timer.issue_key,
+                timer.started_at.format("%Y-%m-%d %H:%M")
+            );
+            Ok(())
+        }
+        Err(WorklogError::NoActiveTimer) => {
+            println!("No active timer to discard");
+            Ok(())
+        }
+        Err(e) => {
+            println!("Unable to discard timer. Cause: {e}");
+            Err(e)
+        }
+    }
+}
+
+pub(crate) fn parse_stop_time(time_str: Option<&str>) -> DateTime<Local> {
+    match time_str {
+        Some(time_str) => match date::str_to_date_time(time_str) {
+            Ok(datetime) => datetime,
+            Err(err) => {
+                eprintln!("Error: Could not parse '{time_str}' as a valid date and time: {err}");
+                eprintln!("Please use one of these formats:");
+                eprintln!("  - Time only (e.g., '08:00') for today at that time");
+                eprintln!("  - Date only (e.g., '2023-05-26') for that date at 08:00");
+                eprintln!("  - Date and time (e.g., '2023-05-26T09:00') for exact specification");
+                exit(1);
+            }
+        },
+        None => Local::now(),
+    }
+}
+
+pub(crate) fn stop_timer(
+    runtime: &ApplicationRuntime,
+    stop_time: DateTime<Local>,
+    comment: Option<String>,
+) -> Result<(), WorklogError> {
+    match runtime.timer_service.stop_active_timer(stop_time, comment) {
+        Ok(timer) => {
+            let duration_seconds = timer.duration().unwrap().num_seconds();
+            let hours = duration_seconds / 3600;
+            let minutes = (duration_seconds % 3600) / 60;
+            println!(
+                "Stopped timer for issue {} with id {:?}, duration: {:02}:{:02} ",
+                timer.issue_key,
+                timer.id.as_ref().unwrap(),
+                hours,
+                minutes
+            );
+            Ok(())
+        }
+        Err(e) => {
+            println!("Unable to stop timer. Cause: {e}");
+            Err(e)
+        }
+    }
+}
+
+pub(crate) async fn sync_timers_to_jira(runtime: &ApplicationRuntime) -> Result<(), WorklogError> {
+    match runtime.timer_service.sync_timers_to_jira().await {
+        Ok(timers) => {
+            println!("Synced {} timers to Jira", timers.len());
+            Ok(())
+        }
+        Err(e) => {
+            println!("Unable to sync timers to Jira. Cause: {e}");
+            Err(e)
+        }
+    }
+}

--- a/worklog/src/repository/sqlite/sqlite_timer_repo.rs
+++ b/worklog/src/repository/sqlite/sqlite_timer_repo.rs
@@ -110,7 +110,11 @@ impl TimerRepository for SqliteTimerRepository {
     }
 
     /// Stops the currently active timer
-    fn stop_active_timer(&self, stop_time: DateTime<Local>) -> Result<Timer, WorklogError> {
+    fn stop_active_timer(
+        &self,
+        stop_time: DateTime<Local>,
+        comment: Option<String>,
+    ) -> Result<Timer, WorklogError> {
         // Find the active timer
         let Some(mut active_timer) = self.find_active_timer()? else {
             return Err(WorklogError::NoActiveTimer);
@@ -121,13 +125,13 @@ impl TimerRepository for SqliteTimerRepository {
             .lock()
             .map_err(|_| WorklogError::DatabaseLockError)?;
 
-        // Set the stop time to supplied value or nLocal::now());
+        // Set the stop time to the supplied value
         active_timer.stopped_at = Some(stop_time);
         debug!("Stopping timer {:?}", &active_timer);
         // Update the timer in the database
         conn.execute(
-            "UPDATE timer SET end = ? WHERE id = ?",
-            params![active_timer.stopped_at, active_timer.id],
+            "UPDATE timer SET end = ?, comment = COALESCE(?, comment) WHERE id = ?",
+            params![active_timer.stopped_at, comment.as_deref(), active_timer.id,],
         )?;
 
         debug!("Stopped timer for issue {}", active_timer.issue_key);

--- a/worklog/src/repository/timer_repository.rs
+++ b/worklog/src/repository/timer_repository.rs
@@ -37,7 +37,11 @@ pub trait TimerRepository: Send + Sync {
     ///
     /// # Returns
     /// * The updated timer entry after being stopped
-    fn stop_active_timer(&self, stop_time: DateTime<Local>) -> Result<Timer, WorklogError>;
+    fn stop_active_timer(
+        &self,
+        stop_time: DateTime<Local>,
+        comment: Option<String>,
+    ) -> Result<Timer, WorklogError>;
 
     /// Finds all timers for a specific issue
     fn find_by_issue_key(&self, issue_key: &str) -> Result<Vec<Timer>, WorklogError>;

--- a/worklog/src/service/timer.rs
+++ b/worklog/src/service/timer.rs
@@ -128,6 +128,7 @@ impl TimerService {
     pub async fn start_timer(
         &self,
         issue_key: &str,
+        started_at: DateTime<Local>,
         comment: Option<String>,
     ) -> Result<Timer, WorklogError> {
         let issue_key = IssueKey::new(issue_key);
@@ -158,13 +159,12 @@ impl TimerService {
             return Err(WorklogError::ActiveTimerExists);
         }
 
-        // Create a new timer with the current time
-        let now = Utc::now();
+        // Create a new timer with the current time as the creation
         let timer = Timer {
             id: None,
             issue_key: issue_key.to_string(),
-            created_at: now.with_timezone(&Local),
-            started_at: now.with_timezone(&Local),
+            created_at: Local::now(),
+            started_at,
             stopped_at: None,
             synced: false,
             comment,
@@ -173,8 +173,8 @@ impl TimerService {
         // Start the timer and get its ID
         let timer_id = self.timer_repository.start_timer(&timer)?;
         debug!(
-            "Started timer with ID: {} for issue {}",
-            timer_id, issue_key
+            "Started timer with ID: {} for issue {}, starting time: {} ",
+            timer_id, issue_key, started_at
         );
 
         // Return the timer with its ID

--- a/worklog/tests/test_helpers/fixtures.rs
+++ b/worklog/tests/test_helpers/fixtures.rs
@@ -29,6 +29,8 @@ pub fn create_test_timer(issue_key: &str, active: bool) -> Timer {
     }
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 pub fn create_worklog_entry(issue_key: IssueKey) -> LocalWorklog {
     LocalWorklog {
         id: "123456789".to_string(),
@@ -57,6 +59,9 @@ pub fn create_test_issue_info() -> IssueSummary {
 }
 
 /// Creates a set of test issues for the database
+
+#[cfg(test)]
+#[allow(dead_code)]
 pub fn create_test_issues() -> Vec<IssueSummary> {
     vec![
         create_test_issue_info(),

--- a/worklog/tests/timer_service_test.rs
+++ b/worklog/tests/timer_service_test.rs
@@ -127,8 +127,11 @@ impl TimerServiceTestContext {
     }
 
     fn stop_timer(&self, end_time: Option<DateTime<Local>>) -> Result<Timer, WorklogError> {
-        self.runtime.timer_service.stop_active_timer(end_time)
+        self.runtime
+            .timer_service
+            .stop_active_timer(end_time.unwrap_or_else(Local::now), None)
     }
+
     // Add a new error to the collection
     fn record_error<E>(&mut self, category: impl Into<String>, error: E)
     where
@@ -296,9 +299,9 @@ async fn test_sync_timers_to_jira() {
         .expect("Failed to start test timer ");
 
     assert_eq!(result.issue_key, test_timer.issue_key);
-    let stop_time = Utc::now().with_timezone(&Local) + Duration::hours(3);
+    let stop_time = Local::now() + Duration::hours(3);
     let timer = timer_service
-        .stop_active_timer(Some(stop_time))
+        .stop_active_timer(stop_time, Some("Test comment at stop".to_string()))
         .expect("Failed to stop test timer");
 
     assert_eq!(result.issue_key, timer.issue_key);

--- a/worklog/tests/timer_service_test.rs
+++ b/worklog/tests/timer_service_test.rs
@@ -70,10 +70,10 @@ impl TimerServiceTestContext {
         self
     }
 
-    async fn start_timer(&self, issue_key: &str) -> Result<Timer, WorklogError> {
+    async fn start_a_timer(&self, issue_key: &str) -> Result<Timer, WorklogError> {
         self.runtime
             .timer_service
-            .start_timer(issue_key, None)
+            .start_timer(issue_key, Local::now(), Some("Test comment".to_string()))
             .await
     }
 
@@ -168,7 +168,7 @@ async fn test_add_worklog_for_non_existing_issue() {
     let result = ctx
         .with_no_issue_in_jira_or_local_database(NON_EXISTENT_KEY)
         .await
-        .start_timer(NON_EXISTENT_KEY)
+        .start_a_timer(NON_EXISTENT_KEY)
         .await;
 
     assert!(
@@ -191,16 +191,23 @@ async fn test_add_worklog_for_existing_issue_in_jira_but_not_in_local_database()
         .await
         .expect("Failed to create issue");
 
-    let result = ctx.start_timer(new_issue.key.as_str()).await;
-
+    let new_timer_result = ctx.start_a_timer(new_issue.key.as_str()).await;
+    let active_timer = ctx.runtime.timer_service.get_active_timer();
     ctx.close().await;
-    match &result {
+
+    match &new_timer_result {
         Ok(_) => assert!(true),
         Err(WorklogError::IssueNotFoundInLocalDBMS(k)) => {
             panic!("Issue not found in local DBMS: {}", k)
         }
         Err(err) => panic!("Failed to start timer: {:?}", err),
     }
+
+    assert!(
+        matches!(active_timer.as_ref(), Ok(Some(t))),
+        "Expected active timer to be Ok(Some(Timer)), but got {:?}",
+        active_timer
+    );
 }
 
 #[tokio::test]
@@ -208,7 +215,7 @@ async fn test_add_worklog_for_existing_issue_in_jira_and_local_database() {
     let mut ctx = TimerServiceTestContext::new();
     let result = ctx.with_issue_in_jira_and_local_database().await;
 
-    let result = ctx.start_timer(result.as_str()).await;
+    let result = ctx.start_a_timer(result.as_str()).await;
     ctx.close().await;
     match &result {
         Ok(_) => assert!(true),
@@ -221,7 +228,7 @@ async fn test_start_and_stop_timer_immediately() {
     let mut ctx = TimerServiceTestContext::new();
     let issue_key = ctx.with_issue_in_jira_and_local_database().await;
 
-    let result = ctx.start_timer(issue_key.as_str()).await;
+    let result = ctx.start_a_timer(issue_key.as_str()).await;
     assert!(result.is_ok());
 
     let result = ctx.stop_timer(None);
@@ -229,7 +236,7 @@ async fn test_start_and_stop_timer_immediately() {
     ctx.close().await;
     match &result {
         Ok(_) => assert!(false, "Stopping timer immediately should fail"),
-        Err(WorklogError::TimerDurationTooSmall(d_)) => {} // What we expected
+        Err(WorklogError::TimerDurationTooSmall(_d)) => {} // What we expected
         _ => panic!("Failed to stop timer: {:?}", result),
     }
 }
@@ -280,7 +287,11 @@ async fn test_sync_timers_to_jira() {
     let test_timer = create_test_timer(test_issue.key.value(), true);
 
     let result = timer_service
-        .start_timer(&test_timer.issue_key, Some("Rubbish".to_string()))
+        .start_timer(
+            &test_timer.issue_key,
+            Local::now(),
+            Some("Rubbish".to_string()),
+        )
         .await
         .expect("Failed to start test timer ");
 

--- a/worklog/tests/timer_service_test.rs
+++ b/worklog/tests/timer_service_test.rs
@@ -4,7 +4,7 @@ mod test_helpers;
 use crate::test_helpers::common::TEST_PROJECT_KEY;
 use crate::test_helpers::fixtures::create_test_timer;
 use crate::test_helpers::issue_tracker::IssueTracker;
-use chrono::{DateTime, Duration, Local, Utc};
+use chrono::{DateTime, Duration, Local};
 use jira::models::core::{Fields, IssueKey};
 use jira::models::issue::{IssueSummary, NewIssueResponse};
 use jira::models::project::JiraProjectKey;
@@ -26,6 +26,8 @@ struct TimerServiceTestContext {
 
 const NON_EXISTENT_KEY: &str = "XXXX-1";
 
+#[cfg(test)]
+#[allow(dead_code)]
 impl TimerServiceTestContext {
     fn new() -> Self {
         // Initialize logger only once
@@ -207,7 +209,7 @@ async fn test_add_worklog_for_existing_issue_in_jira_but_not_in_local_database()
     }
 
     assert!(
-        matches!(active_timer.as_ref(), Ok(Some(t))),
+        matches!(active_timer.as_ref(), Ok(Some(_))),
         "Expected active timer to be Ok(Some(Timer)), but got {:?}",
         active_timer
     );


### PR DESCRIPTION
Made the `start` and `stop`commands more user friendly allowing comments and also to discard a timer when stopping it.